### PR TITLE
Fix make errors and add disclaimer for extra-cmake-modules

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ In order to install the theme and add it to your decorations do the following:
 
 First make sure you have [`extra-cmake-modules`](https://github.com/KDE/extra-cmake-modules) installed:
 
-```
+```shell
 git clone https://github.com/KDE/extra-cmake-modules.git
 cd extra-cmake-modules
 mkdir build && cd build    

--- a/README.md
+++ b/README.md
@@ -3,6 +3,19 @@
 
 
 In order to install the theme and add it to your decorations do the following:
+
+First make sure you have [`extra-cmake-modules`](https://github.com/KDE/extra-cmake-modules) installed:
+
+```
+git clone https://github.com/KDE/extra-cmake-modules.git
+cd extra-cmake-modules
+mkdir build && cd build    
+cmake ..
+make && sudo make install
+```
+
+Then install with:
+
 ``` shell
 git clone https://github.com/jomada/SierraBreeze
 cd SierraBreeze

--- a/breezebutton.cpp
+++ b/breezebutton.cpp
@@ -26,6 +26,7 @@
 #include <KColorUtils>
 
 #include <QPainter>
+#include <QPainterPath>
 
 namespace SierraBreeze
 {


### PR DESCRIPTION
This PR fixes the infamous error when running `sudo make install` (first reported by @muchanem) and adds a disclaimer that [extra-cmake-modules](https://github.com/KDE/extra-cmake-modules) must be installed (and how to do that).